### PR TITLE
Shave off a whopping 3.5 MB from the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk:11-jdk-hotspot
 
 RUN curl -Ls "https://github.com/maxandersen/jbang/releases/download/v0.22.0.2/jbang-0.22.0.2.zip" --output jbang.zip \
-              && jar xf jbang.zip && mv jbang-* jbang && chmod +x jbang/bin/jbang
+              && jar xf jbang.zip && rm jbang.zip && mv jbang-* jbang && chmod +x jbang/bin/jbang
 
 ENTRYPOINT ["/jbang/bin/jbang"]


### PR DESCRIPTION
by deleting jbang.zip, once unzipped