### PR TITLE
(fix) Run with arbitary user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,25 @@ FROM adoptopenjdk:11-jdk-hotspot
 RUN curl -Ls "https://github.com/jbangdev/jbang/releases/download/v0.28.0/jbang-0.28.0.zip" --output jbang.zip \
               && jar xf jbang.zip && rm jbang.zip && mv jbang-* jbang && chmod +x jbang/bin/jbang
 
-ENTRYPOINT ["/jbang/bin/jbang"]
+ADD bin/entrypoint.sh /bin/entrypoint
+
+ENV SCRIPTS_HOME /scripts
+ENV JBANG_VERSION 0.28.0
+
+RUN useradd -u 10001 -r -g 0 -m \
+     -d ${SCRIPTS_HOME} -s /sbin/nologin -c "jbang user" jo \
+   && chmod -R g+w /scripts \
+   && chmod -R g+w /jbang \
+   && chgrp -R root /scripts \
+   && chgrp -R root /jbang \
+   && chmod g+w /etc/passwd \
+   && chmod +x /bin/entrypoint
+
+VOLUME /scripts
+
+USER 10001
+
+ENV PATH="${PATH}:/jbang/bin"
+
+ENTRYPOINT ["entrypoint"]
+CMD ["--help"]

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# In OpenShift, containers are run as a random high number uid
+# that doesn't exist in /etc/passwd
+if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
+
+  cat << EOF > /tmp/passwd
+root:x:0:0:root:/root:/bin/bash
+jbang:x:`id -u`:`id -g`:,,,:/scripts:/bin/bash
+EOF
+
+  cat /tmp/passwd > /etc/passwd
+  rm /tmp/passwd
+fi
+
+exec jbang "${@}"


### PR DESCRIPTION
The update allows jbang container to run as arbitary non root user.  This makes it safe and comptaible to be run on OpenShift.

Fixes #5 