### PR TITLE
Do NOT use USER in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,7 @@ ADD ./entrypoint /bin/entrypoint
 ENV SCRIPTS_HOME /scripts
 ENV JBANG_VERSION 0.38.0
 
-RUN useradd -u 10001 -r -g 0 -m \
-     -d ${SCRIPTS_HOME} -s /sbin/nologin -c "jbang user" jo \
-   && chmod -R g+w /scripts \
-   && chmod -R g+w /jbang \
-   && chgrp -R root /scripts \
-   && chgrp -R root /jbang \
-   && chmod g+w /etc/passwd \
-   && chmod +x /bin/entrypoint
-
 VOLUME /scripts
-
-USER 10001
 
 ENV PATH="${PATH}:/jbang/bin"
 


### PR DESCRIPTION
From the [Github Actions documentation](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user):
> Docker actions must be run by the default Docker user (root). Do not use the USER instruction in your Dockerfile, because you won't be able to access the GITHUB_WORKSPACE. For more information, see "Using environment variables" and USER reference in the Docker documentation.