### PR TITLE
chore: use the existing pre-built image instead

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
       required: false
 runs:
   using: 'docker'
-  image: 'docker://quay.io/jbangdev/jbang-action:0.72.0'
+  image: 'docker://ghcr.io/jbangdev/jbang-action:0.72.0'
  

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
       required: false
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/jbangdev/jbang-action:0.72.0'
+  image: 'docker://ghcr.io/jbangdev/jbang-action:0.78.0'
  

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
       required: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://quay.io/jbangdev/jbang-action:0.72.0'
  


### PR DESCRIPTION
When using the jbang-action, GitHub Actions will always build an image because the image here points to the Dockerfile. Pointing to the docker image makes sure it reuses the pre-built image.

See https://stackoverflow.com/a/60679692

![image](https://user-images.githubusercontent.com/54133/124150292-d0881d00-da67-11eb-8628-a28be2a2ea87.png)
