### PR TITLE
fix: Run locally with 'act' fails (#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,13 @@ RUN jar xf jbang-0.85.1.zip && \
 
 VOLUME /scripts
 
-ENV PATH="${PATH}:/jbang-0.85.1/bin"
-
 ADD ./entrypoint /bin/entrypoint
 
 ENV SCRIPTS_HOME /scripts
 ENV JBANG_VERSION 0.85.1
+ENV JBANG_PATH="/jbang/bin"
 
 VOLUME /scripts
-
-ENV PATH="${PATH}:/jbang/bin"
 
 ## github action does not allow writing to $HOME thus routing this elsewhere
 ENV JBANG_DIR="/jbang/.jbang"

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -9,12 +9,10 @@ LABEL "org.opencontainers.image.revision"="4370e09d63e595f93838fff79b9b617051d97
 
 
 RUN curl -Ls "https://github.com/jbangdev/jbang/releases/download/v0.85.1/jbang-0.85.1.zip" --output jbang-0.85.1.zip && \
-    unzip jbang-0.85.1.zip && \
+    jar xf jbang-0.85.1.zip && \
     rm jbang-0.85.1.zip && \
     chmod +x jbang-0.85.1/bin/jbang
 
 VOLUME /scripts
-
-ENV PATH="${PATH}:/jbang-0.85.1/bin"
 
 ENTRYPOINT ["/jbang-0.85.1/bin/jbang"]

--- a/entrypoint
+++ b/entrypoint
@@ -14,8 +14,11 @@ EOF
 fi
 
 if [[ ! -z "$INPUT_TRUST" ]]; then
-  jbang trust add $INPUT_TRUST
+  $JBANG_PATH/jbang trust add $INPUT_TRUST
 fi
 
 echo jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_ARGS "${@}"
-exec jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"
+
+# Always use jbang full path because 'act' does not let us alter PATH env var in container.
+# See https://github.com/nektos/act/issues/896
+exec $JBANG_PATH/jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"


### PR DESCRIPTION
Use jbang full path to bypass 'act' issue with PATH env var (See https://github.com/nektos/act/issues/896)