### PR TITLE
fix: Run locally with 'act' fails (#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ADD ./entrypoint /bin/entrypoint
 
 ENV SCRIPTS_HOME /scripts
 ENV JBANG_VERSION 0.92.2
+ENV JBANG_PATH=/jbang/bin
 
 VOLUME /scripts
 

--- a/entrypoint
+++ b/entrypoint
@@ -14,8 +14,8 @@ EOF
 fi
 
 if [[ ! -z "$INPUT_TRUST" ]]; then
-  jbang trust add $INPUT_TRUST
+  $JBANG_PATH/jbang trust add $INPUT_TRUST
 fi
 
 echo jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_ARGS "${@}"
-exec jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"
+exec $JBANG_PATH/jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"


### PR DESCRIPTION
Use jbang full path to bypass 'act' issue with PATH environment variable