### PR TITLE
fix: adjust container test for jruby

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -28,7 +28,7 @@ commandTests:
         value: https://github.com/jruby
     command: "entrypoint"
     expectedError:
-        - "Adding .https://github.com/jruby. to /jbang/.jbang/trusted-sources.json"
+      - "Trusting permanently: [https://github.com/jruby]"
   - name: "Does multiple arguments work"
     envVars:
       - key: INPUT_SCRIPT


### PR DESCRIPTION
The error message of `jruby` has changed and therefore, the container-structure-test needs to be adjusted.

See also [error message in the latest build](https://github.com/jbangdev/jbang-action/actions/runs/8505461801/job/23293979418#step:12:150).

Fixes https://github.com/jbangdev/jbang-action/issues/35