### PR TITLE
fix(container-structure-test): adapt expectedError regex

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -28,7 +28,8 @@ commandTests:
         value: https://github.com/jruby
     command: "entrypoint"
     expectedError:
-      - "Trusting permanently: [https://github.com/jruby]"
+      - ".*(Trusting permanently:).*"
+      - ".*(https://github.com/jruby).*"
   - name: "Does multiple arguments work"
     envVars:
       - key: INPUT_SCRIPT


### PR DESCRIPTION
The brackets `[]` seems to cause the regex to be parsed wrongly when using `container-structure-test`.
Therefore, split it into multiple regex and check for each strings individually.

Follow up of https://github.com/jbangdev/jbang-action/pull/36

Related to https://github.com/jbangdev/jbang-action/issues/35