### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
       - name: Github Release
         if:  startsWith(github.ref, 'refs/tags/v')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           body: ${{ format('See https://github.com/jbangdev/jbang/releases/tag/v{0}', env.IMAGE_TAG) }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,14 +22,14 @@ jobs:
       - name: Docker Hub Description
         if: success()
         continue-on-error: true
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: jbangdev/jbang-action
 
       - name: Login to Quay.io
-        uses: actions-hub/docker/login@master
+        uses: actions-hub/docker/login@f5fdbfc3f9d2a9265ead8962c1314108a7b7ec5d # master
         env:
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -38,7 +38,7 @@ jobs:
       - name: Update quay.io Description
         if: success()
         continue-on-error: true
-        uses: jbangdev/jbang-action@v0.49.0
+        uses: jbangdev/jbang-action@3d6ca585ccf4d558c11a504dc21a27f5aeb1c142 # v0.49.0
         with:
           script: .github/workflows/updatequay.java
           args: "--token $TOKEN"
@@ -47,7 +47,7 @@ jobs:
 
       
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /root/.jbang
           key: ${{ runner.os }}-jbang-${{ hashFiles('**/*.java') }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,12 +12,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2    
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2    
     - name: properties@jbangdev from latest release
-      uses: jbangdev/jbang-action@v0.86.0
+      uses: jbangdev/jbang-action@2191f772ca08cbb6db44bc6374c122725acf216f # v0.86.0
       with:
         script: properties@jbangdev
     - name: properties@jbangdev from main
-      uses: jbangdev/jbang-action@main
+      uses: jbangdev/jbang-action@ff16f52fffad177d85a395fe8265e0882eaa5d6e # main
       with:
         script: properties@jbangdev


### PR DESCRIPTION
Pin all action references to full-length commit SHAs for supply chain security.

This is required for enabling the org-level policy:
**Require actions to be pinned to a full-length commit SHA**

Original version tags are preserved as comments for readability.
Consider adding Dependabot for GitHub Actions to keep pins updated:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations to reference specific versions of build tools and actions for improved consistency and reliability across deployment pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-action/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->